### PR TITLE
REFACTOR: replace interface MessageEvaluator by Consumer

### DIFF
--- a/SmartHome/src/main/java/TelegramSmartHome/SmartHome/Config/ConfigService.java
+++ b/SmartHome/src/main/java/TelegramSmartHome/SmartHome/Config/ConfigService.java
@@ -2,7 +2,6 @@ package TelegramSmartHome.SmartHome.Config;
 
 import TelegramSmartHome.SmartHome.SmartHomeApplication;
 import TelegramSmartHome.SmartHome.UserManagement.UserService;
-import TelegramSmartHome.TelegramIO.IMessageEvaluator;
 import TelegramSmartHome.TelegramIO.MessageSendService;
 import TelegramSmartHome.TelegramIO.UpdateService;
 import TelegramSmartHome.TelegramIO.message.Message;
@@ -12,7 +11,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 
-public class ConfigService implements IMessageEvaluator {
+public class ConfigService {
 
     private UpdateService updateService;
     @Setter
@@ -35,7 +34,7 @@ public class ConfigService implements IMessageEvaluator {
 
     public void setUpdateService(UpdateService updateService){
         this.updateService = updateService;
-        updateService.addUpdateListener(this);
+        updateService.addUpdateListener(this::processMessage);
     }
 
     public void registerCache(ConfigCache c) {
@@ -58,7 +57,6 @@ public class ConfigService implements IMessageEvaluator {
         return config.groupsOfUser(username);
     }
 
-    @Override
     public void processMessage(Message message) {
         if(message.getMessageText().startsWith("/bottoken")){
             if(userService.memberOf(message.getSenderUsername(), "administrators")) {

--- a/SmartHome/src/main/java/TelegramSmartHome/SmartHome/SmartCam/SmartCam.java
+++ b/SmartHome/src/main/java/TelegramSmartHome/SmartHome/SmartCam/SmartCam.java
@@ -12,8 +12,6 @@ public class SmartCam {
 
         this.updateService = updateService;
         this.sendService = sendService;
-
-        updateService.addUpdateListener(new SmartCamMessageEvaluator( sendService));
     }
 
 }

--- a/SmartHome/src/main/java/TelegramSmartHome/SmartHome/SmartCam/SmartCamMessageEvaluator.java
+++ b/SmartHome/src/main/java/TelegramSmartHome/SmartHome/SmartCam/SmartCamMessageEvaluator.java
@@ -1,16 +1,9 @@
 package TelegramSmartHome.SmartHome.SmartCam;
 
-import TelegramSmartHome.TelegramIO.IMessageEvaluator;
-import TelegramSmartHome.TelegramIO.message.Message;
 import TelegramSmartHome.TelegramIO.MessageSendService;
 
-public class SmartCamMessageEvaluator implements IMessageEvaluator {
+public class SmartCamMessageEvaluator {
     public SmartCamMessageEvaluator(MessageSendService sendService) {
 
-    }
-
-    @Override
-    public void processMessage(Message message) {
-        System.out.println(message.getMessageText());
     }
 }

--- a/SmartHome/src/main/java/TelegramSmartHome/SmartHome/SystemService/SystemService.java
+++ b/SmartHome/src/main/java/TelegramSmartHome/SmartHome/SystemService/SystemService.java
@@ -1,13 +1,12 @@
 package TelegramSmartHome.SmartHome.SystemService;
 
 import TelegramSmartHome.SmartHome.UserManagement.UserService;
-import TelegramSmartHome.TelegramIO.IMessageEvaluator;
 import TelegramSmartHome.TelegramIO.message.Message;
 import TelegramSmartHome.TelegramIO.MessageSendService;
 import TelegramSmartHome.TelegramIO.UpdateService;
 import io.vavr.control.Try;
 
-public class SystemService implements IMessageEvaluator {
+public class SystemService {
 
     private final UpdateService updateService;
     private final MessageSendService sendService;
@@ -18,10 +17,9 @@ public class SystemService implements IMessageEvaluator {
         this.updateService = updateService;
         this.sendService = sendService;
 
-        updateService.addUpdateListener(this);
+        updateService.addUpdateListener(this::processMessage);
     }
 
-    @Override
     public void processMessage(Message message) {
         switch (message.getMessageText()){
             case "/poweroff":

--- a/TelegramIO/src/main/java/TelegramSmartHome/TelegramIO/IMessageEvaluator.java
+++ b/TelegramIO/src/main/java/TelegramSmartHome/TelegramIO/IMessageEvaluator.java
@@ -1,7 +1,0 @@
-package TelegramSmartHome.TelegramIO;
-
-import TelegramSmartHome.TelegramIO.message.Message;
-
-public interface IMessageEvaluator {
-    void processMessage(Message message);
-}

--- a/TelegramIO/src/main/java/TelegramSmartHome/TelegramIO/UpdateService.java
+++ b/TelegramIO/src/main/java/TelegramSmartHome/TelegramIO/UpdateService.java
@@ -2,16 +2,18 @@ package TelegramSmartHome.TelegramIO;
 
 import TelegramSmartHome.TelegramIO.apicom.HttpsHandler;
 import TelegramSmartHome.TelegramIO.apicom.JsonHandler;
+import TelegramSmartHome.TelegramIO.message.Message;
 import TelegramSmartHome.TelegramIO.message.Update;
 import  io.vavr.control.Try;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.function.Consumer;
 
 public class UpdateService {
     private String token;
     private long lastUpdateId;
-    List<IMessageEvaluator> evaluators;
+    List<Consumer<Message>> evaluators;
     private JsonHandler jsonHandler;
     private HttpsHandler httpsHandler;
 
@@ -33,7 +35,7 @@ public class UpdateService {
      * All Evaluators will receive the updates from Telegram once the start() method is called.
      * @param evaluator
      */
-    public void addUpdateListener(IMessageEvaluator evaluator){
+    public void addUpdateListener(Consumer<Message> evaluator){
         evaluators.add(evaluator);
     }
 
@@ -56,8 +58,9 @@ public class UpdateService {
 
 
     private void notifyUpdateListeners(Update update) {
-        for (IMessageEvaluator evaluator : evaluators){
-            evaluator.processMessage(update.getMessage());
+        Message m = update.getMessage();
+        for (Consumer<Message> evaluator : evaluators){
+            evaluator.accept(m);
         }
     }
 }


### PR DESCRIPTION
Nun müssen nicht mehr alle Klassen die Updates bekommen wollen das Interface implementieren. Sie können beliebige Mathoden einfach direkt als UpdateListener regestrieren lassen.